### PR TITLE
chore: use Node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Check Governance Status'
 description: 'Check governance membership status and casing'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Actions running on Node v12 are deprecated and cause a warning when run.